### PR TITLE
Add `useMultiAlias` Option

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,15 @@
       {
         "title": "Elixir Auto-Alias",
         "properties": {
-          "elixirAutoAlias.useMultiAlias": {
-            "type": "boolean",
-            "default": true,
-            "description": "Use the multi-alias syntax rather than a unique alias for each module within a parent"
+          "elixirAutoAlias": {
+            "type": "object",
+            "properties": {
+              "useMultiAlias": {
+                "type": "boolean",
+                "default": true,
+                "description": "Use the multi-alias syntax rather than a unique alias for each module within a parent"
+              }
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,20 @@
   "categories": [
     "Other"
   ],
+  "contributes": {
+    "configuration": [
+      {
+        "title": "Elixir Auto-Alias",
+        "properties": {
+          "elixirAutoAlias.useMultiAlias": {
+            "type": "boolean",
+            "default": true,
+            "description": "Use the multi-alias syntax rather than a unique alias for each module within a parent"
+          }
+        }
+      }
+    ]
+  },
   "activationEvents": [
     "onLanguage:elixir"
   ],

--- a/src/autocompletion-provider.ts
+++ b/src/autocompletion-provider.ts
@@ -35,7 +35,11 @@ export default class AutocompletionProvider
       return;
     }
 
-    const edit = textEditForForModule(moduleName, text);
+    const edit = textEditForForModule(
+      moduleName,
+      text,
+      this.getUseMultiAlias()
+    );
 
     const parts = moduleParts(moduleName);
 
@@ -54,5 +58,11 @@ export default class AutocompletionProvider
       additionalTextEdits: [vsCodeEdit],
       insertText: parts.name,
     };
+  }
+
+  private getUseMultiAlias(): boolean {
+    return !!vscode.workspace
+      .getConfiguration('elixirAutoAlias')
+      .get('useMultiAlias');
   }
 }

--- a/src/test/unit/document-analysis.test.ts
+++ b/src/test/unit/document-analysis.test.ts
@@ -331,6 +331,7 @@ describe('textEditForForModule', function () {
 					defmodule Abc do
 					end	
 				`,
+        true,
       ],
       expectedOutput: {
         start: { line: 1, character: 0 },
@@ -346,6 +347,7 @@ describe('textEditForForModule', function () {
 					  alias Xyx
 					end
 				`,
+        true,
       ],
       expectedOutput: {
         start: { line: 2, character: 0 },
@@ -360,11 +362,27 @@ describe('textEditForForModule', function () {
 					  alias Foo.Bar.{Abc, Xyz}
 					end
 				`,
+        true,
       ],
       expectedOutput: {
         start: { line: 1, character: 0 },
         end: { line: 1, character: 26 },
         newText: '  alias Foo.Bar.{Abc, Baz, Xyz}',
+      },
+    },
+    {
+      input: [
+        'Foo.Bar.Baz',
+        dedent`
+					defmodule Abc do
+					  alias Foo.Bar.{Abc, Xyz}
+					end
+				`,
+        false,
+      ],
+      expectedOutput: {
+        start: { line: 1, character: 0 },
+        newText: '  alias Foo.Bar.Baz\n',
       },
     },
     {
@@ -375,6 +393,7 @@ describe('textEditForForModule', function () {
             alias Foo.Bar.{Aaa, Bbb}
           end
         `,
+        true,
       ],
       expectedOutput: {
         start: { line: 1, character: 0 },
@@ -390,6 +409,7 @@ describe('textEditForForModule', function () {
             alias Foo.Bar.{Qrs, X}
           end
         `,
+        true,
       ],
       expectedOutput: {
         start: { line: 1, character: 0 },
@@ -405,6 +425,7 @@ describe('textEditForForModule', function () {
                 alias Foo.Bar.{Qrs, X}
           end
         `,
+        true,
       ],
       expectedOutput: {
         start: { line: 1, character: 0 },
@@ -424,6 +445,7 @@ describe('textEditForForModule', function () {
 						end
 					end			
         `,
+        true,
       ],
       expectedOutput: {
         start: { line: 1, character: 0 },

--- a/src/utils/document-analysis.ts
+++ b/src/utils/document-analysis.ts
@@ -193,7 +193,8 @@ export function lineStartOffset(line: string): number {
 
 export function textEditForForModule(
   moduleName: string,
-  document: string
+  document: string,
+  useMultiAlias: boolean
 ): SimpleTextEdit {
   //	Get module prefix
   //	If the module has a prefix and it's already aliased
@@ -204,7 +205,7 @@ export function textEditForForModule(
 
   const lineToUpdate = lineOfUpdatableAlias(moduleName, document);
 
-  if (lineToUpdate !== undefined) {
+  if (useMultiAlias && lineToUpdate !== undefined) {
     const lineText = document.split('\n')[lineToUpdate];
 
     const newLineText = addAliasNameToLine(parts.name, lineText);


### PR DESCRIPTION
Thanks @drewpereli for this plugin; I've been using it for a few days and it's been a nice time-saver.

In some repos that I work in, we don't use multi aliases and I thought it would be convenient to have a configuration property on this plugin to allow us to always create a new `alias Foo.Bar.Fizz`, even if there is a shared parent.

I opted to make the option `useMultiAlias` and have it default to `true`, so the current plugin behavior would remain the same.